### PR TITLE
Parse xml containing multiple Interfaces

### DIFF
--- a/rust/agama-cli/src/wicked.rs
+++ b/rust/agama-cli/src/wicked.rs
@@ -1,7 +1,7 @@
 use crate::error::CliError;
 use crate::printers::{print, Format};
 use agama_migrate_wicked::migrate::migrate;
-use agama_migrate_wicked::reader::read_dir as wicked_read_dir;
+use agama_migrate_wicked::reader::read as wicked_read;
 use clap::Subcommand;
 use std::io;
 
@@ -22,7 +22,7 @@ pub async fn run(subcommand: WickedCommands, format: Format) -> anyhow::Result<(
     let command = parse_wicked_command(subcommand)?;
     match command {
         WickedAction::Show(path) => {
-            let interfaces = wicked_read_dir(path.into()).await?;
+            let interfaces = wicked_read(path.into()).await?;
             print(interfaces, io::stdout(), format)?;
             Ok(())
         }

--- a/rust/agama-migrate-wicked/src/migrate.rs
+++ b/rust/agama-migrate-wicked/src/migrate.rs
@@ -1,4 +1,4 @@
-use crate::reader::read_dir as wicked_read_dir;
+use crate::reader::read as wicked_read;
 use agama_dbus_server::network::{model, Adapter, NetworkManagerAdapter, NetworkState};
 use std::error::Error;
 use std::path::PathBuf;
@@ -16,7 +16,7 @@ impl WickedAdapter {
 impl Adapter for WickedAdapter {
     fn read(&self) -> Result<model::NetworkState, Box<dyn std::error::Error>> {
         async_std::task::block_on(async {
-            let interfaces = wicked_read_dir(self.path.clone()).await?;
+            let interfaces = wicked_read(self.path.clone()).await?;
             let mut state = NetworkState::new(vec![], vec![]);
 
             for interface in interfaces {

--- a/rust/agama-migrate-wicked/src/reader.rs
+++ b/rust/agama-migrate-wicked/src/reader.rs
@@ -19,10 +19,13 @@ fn replace_colons(colon_string: String) -> String {
     replaced
 }
 
-pub async fn read_dir(path: PathBuf) -> Result<Vec<Interface>, io::Error> {
-    let interfaces = fs::read_dir(path)?
-        .map(|res| res.map(|e| read_xml(e.path()).unwrap()).unwrap())
-        .flatten()
-        .collect::<Vec<_>>();
+pub async fn read(path: PathBuf) -> Result<Vec<Interface>, io::Error> {
+    let interfaces: Vec<Interface> = if path.is_dir() {
+        fs::read_dir(path)?
+            .flat_map(|res| res.map(|e| read_xml(e.path()).unwrap()).unwrap())
+            .collect::<Vec<_>>()
+    } else {
+        read_xml(path).unwrap()
+    };
     Ok(interfaces)
 }

--- a/rust/agama-migrate-wicked/src/reader.rs
+++ b/rust/agama-migrate-wicked/src/reader.rs
@@ -5,11 +5,10 @@ use std::fs;
 use std::io;
 use std::path::PathBuf;
 
-pub fn read_xml(path: PathBuf) -> Result<Interface, quick_xml::DeError> {
+pub fn read_xml(path: PathBuf) -> Result<Vec<Interface>, quick_xml::DeError> {
     let contents = fs::read_to_string(path).expect("Should have been able to read the file");
     // TODO better error handling when xml parsing failed
-    let interface: Interface = from_str(replace_colons(contents).as_str())?;
-    Ok(interface)
+    from_str(replace_colons(contents).as_str())
 }
 
 fn replace_colons(colon_string: String) -> String {
@@ -22,7 +21,8 @@ fn replace_colons(colon_string: String) -> String {
 
 pub async fn read_dir(path: PathBuf) -> Result<Vec<Interface>, io::Error> {
     let interfaces = fs::read_dir(path)?
-        .map(|res| res.map(|e| read_xml(e.path()).unwrap()))
-        .collect::<Result<Vec<_>, io::Error>>()?;
+        .map(|res| res.map(|e| read_xml(e.path()).unwrap()).unwrap())
+        .flatten()
+        .collect::<Vec<_>>();
     Ok(interfaces)
 }


### PR DESCRIPTION
## Problem

A single xml file can also contain multiple `Interfaces`.
E.g. running `wicked show-config` without specifying an interface results in a single xml that can contain multiple interfaces.

## Solution

Reading a Vector of Interfaces reads them all. This doesn't change the behaviour for xmls containing a single `Interface`


## Testing

- *Tested manually*
