### PR TITLE
Xml format

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_with",
  "serde_yaml",
  "simplelog",
 ]
@@ -139,6 +140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -389,6 +399,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,8 +491,11 @@ version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
+ "iana-time-zone",
  "num-integer",
  "num-traits",
+ "serde",
+ "winapi",
 ]
 
 [[package]]
@@ -591,6 +610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +690,41 @@ dependencies = [
  "pkg-config",
  "vcpkg",
  "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.26",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -777,6 +837,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -986,6 +1052,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1098,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1013,6 +1109,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -1091,7 +1188,7 @@ checksum = "6ca9e2b45609132ae2214d50482c03aeee78826cd6fd53a8940915b81acedf16"
 dependencies = [
  "ahash",
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "bytecount",
  "fancy-regex",
  "fraction",
@@ -1758,6 +1855,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
+dependencies = [
+ "base64 0.21.4",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.26",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,6 +2406,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/rust/agama-migrate-wicked/Cargo.toml
+++ b/rust/agama-migrate-wicked/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4.1.4", features = ["derive", "wrap_help"] }
 anyhow = "1.0.71"
 log = "0.4"
 simplelog = "0.12.1"
+serde_with = "3.3.0"
 
 [[bin]]
 name = "migrate-wicked"

--- a/rust/agama-migrate-wicked/src/interface.rs
+++ b/rust/agama-migrate-wicked/src/interface.rs
@@ -1,6 +1,7 @@
 use agama_dbus_server::network::model::{self, IpConfig, IpMethod, Parent};
 use cidr::IpInet;
 use serde::{Deserialize, Deserializer, Serialize};
+use serde_with::{formats::CommaSeparator, serde_as, StringWithSeparator};
 use std::{collections::HashMap, str::FromStr};
 
 #[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
@@ -85,12 +86,13 @@ pub struct Address {
     pub local: String,
 }
 
+#[serde_as]
 #[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Ipv6Dhcp {
     pub enabled: bool,
     pub flags: String,
-    #[serde(deserialize_with = "comma_separated_string_deserialize")]
+    #[serde_as(as = "StringWithSeparator::<CommaSeparator, String>")]
     pub update: Vec<String>,
     pub mode: String,
     #[serde(rename = "rapid-commit")]
@@ -106,24 +108,13 @@ pub struct Ipv6Dhcp {
     pub release_lease: bool,
 }
 
+#[serde_as]
 #[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Ipv6Auto {
     pub enabled: bool,
-    #[serde(deserialize_with = "comma_separated_string_deserialize")]
+    #[serde_as(as = "StringWithSeparator::<CommaSeparator, String>")]
     pub update: Vec<String>,
-}
-
-// https://stackoverflow.com/questions/54006221/how-can-i-deserialize-a-comma-separated-json-string-as-a-vector-of-separate-stri
-fn comma_separated_string_deserialize<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let str_sequence = String::deserialize(deserializer)?;
-    Ok(str_sequence
-        .split(',')
-        .map(|item| item.to_owned())
-        .collect())
 }
 
 #[derive(Debug, PartialEq, Default, Serialize, Deserialize)]

--- a/rust/agama-migrate-wicked/src/interface.rs
+++ b/rust/agama-migrate-wicked/src/interface.rs
@@ -22,6 +22,8 @@ pub struct Interface {
     pub ipv6_auto: Option<Ipv6Auto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bond: Option<Bond>,
+    #[serde(rename = "@origin")]
+    pub origin: String,
 }
 
 #[derive(Debug, PartialEq, Serialize, Clone, Deserialize)]

--- a/rust/agama-migrate-wicked/src/main.rs
+++ b/rust/agama-migrate-wicked/src/main.rs
@@ -49,6 +49,7 @@ pub enum Format {
     Json,
     PrettyJson,
     Yaml,
+    Xml,
     Text,
 }
 
@@ -60,6 +61,7 @@ async fn run_command(cli: Cli) -> anyhow::Result<()> {
                 Format::Json => serde_json::to_string(&interfaces)?,
                 Format::PrettyJson => serde_json::to_string_pretty(&interfaces)?,
                 Format::Yaml => serde_yaml::to_string(&interfaces)?,
+                Format::Xml => quick_xml::se::to_string_with_root("interface", &interfaces)?,
                 Format::Text => format!("{:?}", interfaces),
             };
             println!("{}", output);


### PR DESCRIPTION
## Problem

No xml output

## Solution

Add xml output
I also added the origin property to make the output more close to the original, though due to the regex we are doing with e.g. `ipv4:static` to `ipv4-static` something like a round trip test, where we parse the xml and compare the output to the original, is unfortunately not possible right now.
And the comma separated strings are now parsed with the serde_with crate, which has the benefit of deserializing into comma separated strings, which again matches the original more closely.

## Testing

- *Tested manually*
