### PR TITLE
Add possibility to specify multiple files in cli

### DIFF
--- a/rust/agama-migrate-wicked/src/main.rs
+++ b/rust/agama-migrate-wicked/src/main.rs
@@ -33,13 +33,13 @@ pub enum Commands {
         #[arg(value_enum, short, long, default_value_t = Format::Json)]
         format: Format,
 
-        /// Path to file or directory where the wicked xml config is located
-        path: String,
+        /// Wicked XML Files or directories where the wicked xml configs are located
+        paths: Vec<String>,
     },
     /// Migrate wicked state at path
     Migrate {
-        /// Path to file or directory where the wicked xml config is located
-        path: String,
+        /// Wicked XML Files or directories where the wicked xml configs are located
+        paths: Vec<String>,
     },
 }
 
@@ -54,8 +54,8 @@ pub enum Format {
 
 async fn run_command(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
-        Commands::Show { path, format } => {
-            let interfaces = wicked_read(path.into()).await?;
+        Commands::Show { paths, format } => {
+            let interfaces = wicked_read(paths).await?;
             let output: String = match format {
                 Format::Json => serde_json::to_string(&interfaces)?,
                 Format::PrettyJson => serde_json::to_string_pretty(&interfaces)?,
@@ -65,8 +65,8 @@ async fn run_command(cli: Cli) -> anyhow::Result<()> {
             println!("{}", output);
             Ok(())
         }
-        Commands::Migrate { path } => {
-            migrate(path).await.unwrap();
+        Commands::Migrate { paths } => {
+            migrate(paths).await.unwrap();
             Ok(())
         }
     }

--- a/rust/agama-migrate-wicked/src/reader.rs
+++ b/rust/agama-migrate-wicked/src/reader.rs
@@ -38,15 +38,20 @@ pub fn post_process_interface(interfaces: &mut [Interface]) {
     }
 }
 
-pub async fn read(path: PathBuf) -> Result<Vec<Interface>, io::Error> {
-    let mut interfaces: Vec<Interface> = if path.is_dir() {
-        fs::read_dir(path)?
-            .filter(|r| !r.as_ref().unwrap().path().is_dir())
-            .flat_map(|res| res.map(|e| read_xml(e.path()).unwrap()).unwrap())
-            .collect::<Vec<_>>()
-    } else {
-        read_xml(path).unwrap()
-    };
+pub async fn read(paths: Vec<String>) -> Result<Vec<Interface>, io::Error> {
+    let mut interfaces: Vec<Interface> = vec![];
+    for path in paths {
+        let path: PathBuf = path.into();
+        let mut new_interfaces: Vec<Interface> = if path.is_dir() {
+            fs::read_dir(path)?
+                .filter(|r| !r.as_ref().unwrap().path().is_dir())
+                .flat_map(|res| res.map(|e| read_xml(e.path()).unwrap()).unwrap())
+                .collect::<Vec<_>>()
+        } else {
+            read_xml(path).unwrap()
+        };
+        interfaces.append(&mut new_interfaces);
+    }
     post_process_interface(&mut interfaces);
     Ok(interfaces)
 }


### PR DESCRIPTION
## Problem

Using the cli to run e.g. `wicked-migrate show tests/*` isn't possible currently


## Solution

Allow multiple files or directories to be parsed to the cli.
Note: The solution is a bit more complicated because `post_process_interface()` needs to work.


## Testing

- *Tested manually*
