### PR TITLE
bond: add option fail-over-mac

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -110,6 +110,8 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "simplelog",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -1792,6 +1794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,6 +1998,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.26",
+]
 
 [[package]]
 name = "subtle"

--- a/rust/agama-migrate-wicked/Cargo.toml
+++ b/rust/agama-migrate-wicked/Cargo.toml
@@ -19,6 +19,8 @@ clap = { version = "4.1.4", features = ["derive", "wrap_help"] }
 anyhow = "1.0.71"
 log = "0.4"
 simplelog = "0.12.1"
+strum = "0.25.0"
+strum_macros = "0.25.2"
 serde_with = "3.3.0"
 
 [[bin]]


### PR DESCRIPTION
Implementing a bond option `fail-over-mac`. I'm using an Enum as representation of the values and also did some small tests. I will use this approach (if ok) for other options in similar way.