### PR TITLE
Better xml error handling

### DIFF
--- a/rust/agama-migrate-wicked/src/main.rs
+++ b/rust/agama-migrate-wicked/src/main.rs
@@ -56,7 +56,7 @@ pub enum Format {
 async fn run_command(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         Commands::Show { paths, format } => {
-            let interfaces = wicked_read(paths).await?;
+            let interfaces = wicked_read(paths)?;
             let output: String = match format {
                 Format::Json => serde_json::to_string(&interfaces)?,
                 Format::PrettyJson => serde_json::to_string_pretty(&interfaces)?,

--- a/rust/agama-migrate-wicked/src/migrate.rs
+++ b/rust/agama-migrate-wicked/src/migrate.rs
@@ -15,7 +15,7 @@ impl WickedAdapter {
 impl Adapter for WickedAdapter {
     fn read(&self) -> Result<model::NetworkState, Box<dyn std::error::Error>> {
         async_std::task::block_on(async {
-            let interfaces = wicked_read(self.paths.clone()).await?;
+            let interfaces = wicked_read(self.paths.clone())?;
             let mut state = NetworkState::new(vec![], vec![]);
 
             for interface in interfaces {

--- a/rust/agama-migrate-wicked/src/reader.rs
+++ b/rust/agama-migrate-wicked/src/reader.rs
@@ -103,4 +103,18 @@ mod tests {
             Some(crate::interface::FailOverMac::None)
         );
     }
+
+    #[test]
+    fn test_broken_xml() {
+        let xml = r##"
+            <interface>
+                <name>eth1</name>
+                <ipv4:static>
+                  <address>127.0.0.1</>
+                </ipv4:static>
+            </interface>
+            "##;
+        let err = read_xml(xml);
+        assert!(err.is_err());
+    }
 }

--- a/rust/agama-migrate-wicked/src/reader.rs
+++ b/rust/agama-migrate-wicked/src/reader.rs
@@ -9,9 +9,18 @@ pub fn read_xml(str: &str) -> Result<Vec<Interface>, quick_xml::DeError> {
     from_str(replace_colons(str).as_str())
 }
 
-pub fn read_xml_file(path: PathBuf) -> Result<Vec<Interface>, quick_xml::DeError> {
-    let contents = fs::read_to_string(path).expect("Should have been able to read the file");
-    read_xml(contents.as_str())
+pub fn read_xml_file(path: PathBuf) -> Result<Vec<Interface>, anyhow::Error> {
+    let contents = match fs::read_to_string(path.clone()) {
+        Ok(contents) => contents,
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "Couldn't read {}: {}",
+                path.as_path().display(),
+                e
+            ))
+        }
+    };
+    Ok(read_xml(contents.as_str())?)
 }
 
 fn replace_colons(colon_string: &str) -> String {


### PR DESCRIPTION
## Problem

Errors when parsing the xml file currently only resulted in a panic without indicating what went wrong.

## Solution

Now a proper error is reported which then gets printed, which makes debugging problems a lot more simple.

## Testing

- *Added new unit test*
- *Tested manually*