### PR TITLE
bond-options: finalize bonding options

### DIFF
--- a/rust/agama-migrate-wicked/src/interface.rs
+++ b/rust/agama-migrate-wicked/src/interface.rs
@@ -131,16 +131,92 @@ pub enum FailOverMac {
     Follow,
 }
 
-#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, SerializeDisplay, DeserializeFromStr, EnumString, Display)]
+#[strum(serialize_all = "kebab_case")]
+pub enum XmitHashPolicy {
+    Layer2,
+    Layer23,
+    Layer34,
+    Encap23,
+    Encap34,
+}
+
+#[derive(Debug, PartialEq, SerializeDisplay, DeserializeFromStr, EnumString, Display)]
+#[strum(serialize_all = "kebab_case")]
+pub enum LacpRate {
+    Slow,
+    Fast,
+}
+
+#[derive(Debug, PartialEq, SerializeDisplay, DeserializeFromStr, EnumString, Display)]
+#[strum(serialize_all = "kebab_case")]
+pub enum AdSelect {
+    Stable,
+    Bandwidth,
+    Count,
+}
+
+#[derive(Debug, PartialEq, SerializeDisplay, DeserializeFromStr, EnumString, Display)]
+#[strum(serialize_all = "kebab_case")]
+pub enum PrimaryReselect {
+    Always,
+    Better,
+    Failure,
+}
+
+#[derive(Debug, PartialEq, SerializeDisplay, DeserializeFromStr, EnumString, Display)]
+#[strum(serialize_all = "kebab_case")]
+pub enum BondMode {
+    BalanceRr = 0,
+    ActiveBackup,
+    BalanceXor,
+    Broadcast,
+    #[strum(serialize = "802.3ad")]
+    IEEE8023ad,
+    BalanceTlb,
+    BalanceAlb,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[skip_serializing_none]
+#[serde(rename_all = "kebab-case")]
 pub struct Bond {
-    pub mode: String,
+    pub mode: BondMode,
     pub miimon: Option<Miimon>,
     pub arpmon: Option<ArpMon>,
     #[serde(deserialize_with = "unwrap_slaves")]
     pub slaves: Vec<Slave>,
-    #[serde(rename = "fail-over-mac")]
+    /* only on mode=[802.3ad, balance_xor] */
+    pub xmit_hash_policy: Option<XmitHashPolicy>,
+    /* only on mode=balance_rr */
+    pub packets_per_slave: Option<u32>,
+    /* only on mode=balance_tlb */
+    pub tlb_dynamic_lb: Option<bool>,
+    /* only on mode=802.3ad */
+    pub lacp_rate: Option<LacpRate>,
+    /* only on mode=802.3ad */
+    pub ad_select: Option<AdSelect>,
+    /* only on mode=802.3ad */
+    pub ad_user_port_key: Option<u32>,
+    /* only on mode=802.3ad */
+    pub ad_actor_sys_prio: Option<u32>,
+    /* only on mode=802.3ad */
+    pub ad_actor_system: Option<String>,
+    /* only on mode=802.3ad */
+    pub min_links: Option<u32>,
+    /* only on mode=active-backup */
+    pub primary_reselect: Option<PrimaryReselect>,
+    /* only on mode=active-backup */
     pub fail_over_mac: Option<FailOverMac>,
+    /* only on mode=active-backup */
+    pub num_grat_arp: Option<u32>,
+    /* only on mode=active-backup */
+    pub num_usol_na: Option<u32>,
+    /* only on mode=[balance_tlb|balance_alb] */
+    pub lp_interval: Option<u32>,
+    /* only on mode=[balance_tlb|balance_alb|balance_RR|active-backup] */
+    pub resend_igmp: Option<u32>,
+    pub all_slaves_active: Option<bool>,
 }
 
 impl Bond {
@@ -161,27 +237,62 @@ pub struct Slave {
     pub primary: Option<bool>,
 }
 
+#[derive(Debug, PartialEq, Default, SerializeDisplay, DeserializeFromStr, EnumString, Display)]
+#[strum(serialize_all = "kebab_case")]
+pub enum CarrierDetect {
+    Ioctl = 0,
+    #[default]
+    Netif = 1,
+}
+
 #[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct Miimon {
     pub frequency: u32,
     #[serde(rename = "carrier-detect")]
-    pub carrier_detect: String,
+    pub carrier_detect: CarrierDetect,
+    pub downdelay: Option<u32>,
+    pub updelay: Option<u32>,
 }
 
-#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, SerializeDisplay, DeserializeFromStr, EnumString, Display)]
+#[strum(serialize_all = "kebab_case")]
+pub enum ArpValidateTargets {
+    Any = 0,
+    All = 1,
+}
+
+#[derive(Debug, PartialEq, SerializeDisplay, DeserializeFromStr, EnumString, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum ArpValidate {
+    None = 0,
+    Active = 1,
+    Backup = 2,
+    All = 3,
+    Filter = 4,
+    FilterActive = 5,
+    FilterBackup = 6,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ArpMon {
     pub interval: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub validate: Option<String>,
-    #[serde(rename = "validate-target")]
-    pub validate_target: Option<String>,
-    pub targets: Vec<ArpMonTargetAddressV4>,
+    pub validate: ArpValidate,
+    #[serde(rename = "validate-targets", skip_serializing_if = "Option::is_none")]
+    pub validate_targets: Option<ArpValidateTargets>,
+    #[serde(deserialize_with = "unwrap_arpmon_targets")]
+    pub targets: Vec<String>,
 }
 
-#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
-pub struct ArpMonTargetAddressV4 {
-    #[serde(rename = "ipv4-address")]
-    pub ipv4_address: String,
+fn unwrap_arpmon_targets<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
+    pub struct ArpMonTargetAddressV4 {
+        #[serde(rename = "ipv4-address")]
+        pub ipv4_address: Vec<String>,
+    }
+    Ok(ArpMonTargetAddressV4::deserialize(deserializer)?.ipv4_address)
 }
 
 fn unwrap_slaves<'de, D>(deserializer: D) -> Result<Vec<Slave>, D::Error>
@@ -199,39 +310,108 @@ impl From<Bond> for HashMap<String, String> {
     fn from(bond: Bond) -> HashMap<String, String> {
         let mut h: HashMap<String, String> = HashMap::new();
 
-        h.insert(String::from("mode"), bond.mode.clone());
+        h.insert(String::from("mode"), bond.mode.to_string());
         if let Some(p) = bond.primary() {
             h.insert(String::from("primary"), p.clone());
         }
 
         if let Some(m) = &bond.miimon {
             h.insert(String::from("miimon"), format!("{}", m.frequency));
+            h.insert(
+                String::from("carrier_detect"),
+                match m.carrier_detect {
+                    CarrierDetect::Ioctl => 0,
+                    CarrierDetect::Netif => 1,
+                }
+                .to_string(),
+            );
+            if let Some(v) = m.downdelay {
+                h.insert(String::from("downdelay"), v.to_string());
+            }
+            if let Some(v) = m.updelay {
+                h.insert(String::from("updelay"), v.to_string());
+            }
         }
 
         if let Some(a) = &bond.arpmon {
             h.insert(String::from("arp_interval"), format!("{}", a.interval));
-            if let Some(v) = &a.validate {
-                h.insert(String::from("arp_validate"), v.clone());
-            }
+            h.insert(String::from("arp_validate"), a.validate.to_string());
 
             if !a.targets.is_empty() {
                 let sv = a
                     .targets
                     .iter()
-                    .map(|c| c.ipv4_address.as_ref())
+                    .map(|c| c.as_ref())
                     .collect::<Vec<&str>>()
                     .join(",");
                 h.insert(String::from("arp_ip_target"), sv);
             }
 
-            if let Some(v) = &a.validate_target {
-                h.insert(String::from("arp_all_targets"), v.clone());
+            if let Some(v) = &a.validate_targets {
+                h.insert(String::from("arp_all_targets"), v.to_string());
             }
         }
 
         if let Some(fom) = &bond.fail_over_mac {
-            h.insert(String::from("fail-over-mac"), fom.to_string());
+            h.insert(String::from("fail_over_mac"), fom.to_string());
         }
+
+        if let Some(v) = &bond.xmit_hash_policy {
+            h.insert(String::from("xmit_hash_policy"), v.to_string());
+        }
+
+        if let Some(v) = &bond.packets_per_slave {
+            h.insert(String::from("packets_per_slave"), v.to_string());
+        }
+
+        if let Some(v) = &bond.tlb_dynamic_lb {
+            h.insert(
+                String::from("tlb_dynamic_lb"),
+                if *v { 1.to_string() } else { 0.to_string() },
+            );
+        }
+
+        if let Some(v) = &bond.lacp_rate {
+            h.insert(String::from("lacp_rate"), v.to_string());
+        }
+
+        if let Some(v) = &bond.ad_select {
+            h.insert(String::from("ad_select"), v.to_string());
+        }
+        if let Some(v) = &bond.ad_user_port_key {
+            h.insert(String::from("ad_user_port_key"), v.to_string());
+        }
+        if let Some(v) = &bond.ad_actor_sys_prio {
+            h.insert(String::from("ad_actor_sys_prio"), v.to_string());
+        }
+        if let Some(v) = &bond.ad_actor_system {
+            h.insert(String::from("ad_actor_system"), v.clone());
+        }
+        if let Some(v) = &bond.min_links {
+            h.insert(String::from("min_links"), v.to_string());
+        }
+        if let Some(v) = &bond.primary_reselect {
+            h.insert(String::from("primary_reselect"), v.to_string());
+        }
+        if let Some(v) = &bond.num_grat_arp {
+            h.insert(String::from("num_grat_arp"), v.to_string());
+        }
+        if let Some(v) = &bond.num_usol_na {
+            h.insert(String::from("num_usol_na"), v.to_string());
+        }
+        if let Some(v) = &bond.lp_interval {
+            h.insert(String::from("lp_interval"), v.to_string());
+        }
+        if let Some(v) = &bond.resend_igmp {
+            h.insert(String::from("resend_igmp"), v.to_string());
+        }
+        if let Some(v) = &bond.all_slaves_active {
+            h.insert(
+                String::from("all_slaves_active"),
+                if *v { 1.to_string() } else { 0.to_string() },
+            );
+        }
+
         h
     }
 }
@@ -385,12 +565,82 @@ mod tests {
     #[test]
     fn test_bond_options() {
         let bond = Bond {
+            mode: BondMode::IEEE8023ad,
+            xmit_hash_policy: Some(XmitHashPolicy::Encap34),
             fail_over_mac: Some(FailOverMac::Active),
-            ..Default::default()
+            packets_per_slave: Some(23),
+            tlb_dynamic_lb: Some(true),
+            lacp_rate: Some(LacpRate::Slow),
+            ad_select: Some(AdSelect::Bandwidth),
+            ad_user_port_key: Some(42),
+            ad_actor_sys_prio: Some(5),
+            ad_actor_system: Some(String::from("00:de:ad:be:ef:00")),
+            min_links: Some(3),
+            primary_reselect: Some(PrimaryReselect::Better),
+            num_grat_arp: Some(7),
+            num_usol_na: Some(13),
+            lp_interval: Some(17),
+            resend_igmp: Some(19),
+            all_slaves_active: Some(true),
+            miimon: Some(Miimon {
+                frequency: 42,
+                carrier_detect: CarrierDetect::Netif,
+                downdelay: Some(23),
+                updelay: Some(5),
+            }),
+            arpmon: Some(ArpMon {
+                interval: 23,
+                validate: ArpValidate::FilterBackup,
+                validate_targets: Some(ArpValidateTargets::Any),
+                targets: vec![String::from("1.2.3.4"), String::from("4.3.2.1")],
+            }),
+            slaves: vec![],
         };
 
         let bond: HashMap<String, String> = bond.into();
-        assert!(bond.contains_key("fail-over-mac"));
-        assert_eq!(bond.get("fail-over-mac").unwrap(), "active");
+        let s = HashMap::from([
+            ("xmit_hash_policy", String::from("encap34")),
+            ("packets_per_slave", 23.to_string()),
+            ("tlb_dynamic_lb", 1.to_string()),
+            ("lacp_rate", String::from("slow")),
+            ("ad_select", String::from("bandwidth")),
+            ("ad_user_port_key", 42.to_string()),
+            ("ad_actor_sys_prio", 5.to_string()),
+            ("ad_actor_system", String::from("00:de:ad:be:ef:00")),
+            ("min_links", 3.to_string()),
+            ("primary_reselect", String::from("better")),
+            ("fail_over_mac", String::from("active")),
+            ("num_grat_arp", 7.to_string()),
+            ("num_usol_na", 13.to_string()),
+            ("lp_interval", 17.to_string()),
+            ("resend_igmp", 19.to_string()),
+            ("all_slaves_active", 1.to_string()),
+            // miimon
+            ("miimon", 42.to_string()),
+            ("carrier_detect", 1.to_string()),
+            ("downdelay", 23.to_string()),
+            ("updelay", 5.to_string()),
+            // arpmon
+            ("arp_validate", String::from("filter_backup")),
+            ("arp_all_targets", String::from("any")),
+            ("arp_ip_target", String::from("1.2.3.4,4.3.2.1")),
+            ("arp_interval", 23.to_string()),
+        ]);
+
+        for (k, v) in s.iter() {
+            assert!(
+                bond.contains_key(*k),
+                "Missing key '{}' in bond hash {:?}",
+                *k,
+                bond
+            );
+            assert_eq!(
+                bond.get(*k).unwrap(),
+                v,
+                "Unexpected value '{}' in key '{}'",
+                *k,
+                v
+            );
+        }
     }
 }

--- a/rust/agama-migrate-wicked/src/reader.rs
+++ b/rust/agama-migrate-wicked/src/reader.rs
@@ -89,27 +89,93 @@ pub fn read(paths: Vec<String>) -> Result<Vec<Interface>, anyhow::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::interface::*;
 
     #[test]
-    fn test_bond_option_fail_over_mac() {
+    fn test_bond_options_from_xml() {
         let xml = r##"
             <interface>
                 <name>bond0</name>
                 <bond>
                     <mode>active-backup</mode>
+                    <xmit-hash-policy>layer34</xmit-hash-policy>
                     <fail-over-mac>none</fail-over-mac>
+                    <packets-per-slave>1</packets-per-slave>
+                    <tlb-dynamic-lb>true</tlb-dynamic-lb>
+                    <lacp-rate>slow</lacp-rate>
+                    <ad-select>bandwidth</ad-select>
+                    <ad-user-port-key>5</ad-user-port-key>
+                    <ad-actor-sys-prio>7</ad-actor-sys-prio>
+                    <ad-actor-system>00:de:ad:be:ef:00</ad-actor-system>
+                    <min-links>11</min-links>
+                    <primary-reselect>better</primary-reselect>
+                    <num-grat-arp>13</num-grat-arp>
+                    <num-usol-na>17</num-usol-na>
+                    <lp-interval>19</lp-interval>
+                    <resend-igmp>23</resend-igmp>
+                    <all-slaves-active>true</all-slaves-active>
                     <slaves>
                         <slave><device>en0</device></slave>
                     </slaves>
+                    <miimon>
+                        <frequency>23</frequency>
+                        <updelay>27</updelay>
+                        <downdelay>31</downdelay>
+                        <carrier-detect>ioctl</carrier-detect>
+                    </miimon>
+                    <arpmon>
+                        <interval>23</interval>
+                        <validate>filter_backup</validate>
+                        <validate-targets>any</validate-targets>
+                        <targets>
+                            <ipv4-address>1.2.3.4</ipv4-address>
+                            <ipv4-address>4.3.2.1</ipv4-address>
+                        </targets>
+                    </arpmon>
                 </bond>
             </interface>
             "##;
         let ifc = read_xml(xml).unwrap().pop().unwrap();
         assert!(ifc.bond.is_some());
         let bond = ifc.bond.unwrap();
+
         assert_eq!(
-            bond.fail_over_mac,
-            Some(crate::interface::FailOverMac::None)
+            bond,
+            Bond {
+                mode: BondMode::ActiveBackup,
+                xmit_hash_policy: Some(XmitHashPolicy::Layer34),
+                fail_over_mac: Some(FailOverMac::None),
+                packets_per_slave: Some(1),
+                tlb_dynamic_lb: Some(true),
+                lacp_rate: Some(LacpRate::Slow),
+                ad_select: Some(AdSelect::Bandwidth),
+                ad_user_port_key: Some(5),
+                ad_actor_sys_prio: Some(7),
+                ad_actor_system: Some(String::from("00:de:ad:be:ef:00")),
+                min_links: Some(11),
+                primary_reselect: Some(PrimaryReselect::Better),
+                num_grat_arp: Some(13),
+                num_usol_na: Some(17),
+                lp_interval: Some(19),
+                resend_igmp: Some(23),
+                all_slaves_active: Some(true),
+                slaves: vec![Slave {
+                    device: String::from("en0"),
+                    primary: None
+                }],
+                miimon: Some(Miimon {
+                    frequency: 23,
+                    carrier_detect: CarrierDetect::Ioctl,
+                    downdelay: Some(31),
+                    updelay: Some(27),
+                }),
+                arpmon: Some(ArpMon {
+                    interval: 23,
+                    validate: ArpValidate::FilterBackup,
+                    validate_targets: Some(ArpValidateTargets::Any),
+                    targets: vec![String::from("1.2.3.4"), String::from("4.3.2.1")]
+                }),
+            }
         );
     }
 


### PR DESCRIPTION
This finalize the bond option parsing and creation of bond options hash.

The missing peace is the `<address>` field, which contains a mac-address. But this need also a change inside the agama model and will come with a separate PR as I will also change the Upstream with it.