### PR TITLE
Automatic OBS package update

### DIFF
--- a/.github/workflows/configure_osc.sh
+++ b/.github/workflows/configure_osc.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+# This helper script creates the "osc" configuration file with OBS credentials
+
+CONFIG_FILE="$HOME/.config/osc/oscrc"
+
+# do not overwrite the existing config accidentally
+if [ -e "$CONFIG_FILE" ]; then
+    echo "ERROR: $CONFIG_FILE already exists"
+    exit 1
+fi
+
+TEMPLATE=$(dirname "${BASH_SOURCE[0]}")/oscrc.template
+mkdir -p $(dirname "$CONFIG_FILE")
+sed -e "s/@OBS_USER@/$OBS_USER/g" -e "s/@OBS_PASSWORD@/$OBS_PASSWORD/g" "$TEMPLATE" > "$CONFIG_FILE"

--- a/.github/workflows/obs-build.yml
+++ b/.github/workflows/obs-build.yml
@@ -1,0 +1,53 @@
+name: Update OBS Git Package
+
+on:
+  push:
+    branches:
+      - wicked-nm-migration
+    paths:
+      - rust/migrate-wicked/**
+
+jobs:
+  update_obs_package:
+    # do not run in forks
+    if: github.repository == 'jcronenberg/agama'
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: registry.opensuse.org/opensuse/tumbleweed:latest
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure and refresh repositories
+        # disable unused repositories to have a faster refresh
+        run: zypper modifyrepo -d repo-non-oss repo-openh264 repo-update && zypper ref
+
+      - name: Install tools
+        run: zypper --non-interactive install --no-recommends
+             git
+             obs-service-obs_scm
+             obs-service-cargo_vendor
+             obs-service-set_version
+             obs-service-tar
+             osc
+             cpio
+
+      - name: Configure osc
+        run: .github/workflows/configure_osc.sh
+        env:
+          OBS_USER:     jcronenberg_bot
+          OBS_PASSWORD: ${{ secrets.OBS_PW }}
+
+      - name: Checkout package
+        run: osc checkout home:jcronenberg:migrate-wicked/migrate-wicked-git -o migrate-wicked-git-package
+
+      - name: Run osc service manualrun
+        run: osc service manualrun
+        working-directory: ./migrate-wicked-git-package
+
+      - name: Commit to OBS
+        run: osc commit -m "$GITHUB_SHA"
+        working-directory: ./migrate-wicked-git-package

--- a/.github/workflows/oscrc.template
+++ b/.github/workflows/oscrc.template
@@ -1,0 +1,7 @@
+[general]
+apiurl = https://api.opensuse.org
+
+[https://api.opensuse.org]
+user=@OBS_USER@
+pass=@OBS_PASSWORD@
+credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager


### PR DESCRIPTION
## Problem

For testing in OpenQA we need to update the migrate-wicked-git rpm at https://build.opensuse.org/project/show/home:jcronenberg:migrate-wicked when changes happen.

## Solution

Add a github workflow that pushes changes to OBS when updates to the wicked-nm-migration branch happen.

## Testing

- *Tested manually*
https://github.com/jcronenberg/agama/actions/runs/7129990844/job/19415342505
https://build.opensuse.org/package/show/home:jcronenberg:migrate-wicked/migrate-wicked-git