### PR TITLE
Add dry-run cli argument to migrate cmd

### DIFF
--- a/rust/migrate-wicked/src/main.rs
+++ b/rust/migrate-wicked/src/main.rs
@@ -45,6 +45,10 @@ pub enum Commands {
         /// Continue migration if warnings are encountered
         #[arg(short, long, global = true)]
         continue_migration: bool,
+
+        /// Run migration without sending connections to NetworkManager (can be run without NetworkManager installed)
+        #[arg(long, global = true)]
+        dry_run: bool,
     },
 }
 
@@ -64,6 +68,7 @@ async fn run_command(cli: Cli) -> anyhow::Result<()> {
             MIGRATION_SETTINGS
                 .set(MigrationSettings {
                     continue_migration: true,
+                    dry_run: false,
                 })
                 .expect("MIGRATION_SETTINGS was set too early");
 
@@ -83,9 +88,13 @@ async fn run_command(cli: Cli) -> anyhow::Result<()> {
         Commands::Migrate {
             paths,
             continue_migration,
+            dry_run,
         } => {
             MIGRATION_SETTINGS
-                .set(MigrationSettings { continue_migration })
+                .set(MigrationSettings {
+                    continue_migration,
+                    dry_run,
+                })
                 .expect("MIGRATION_SETTINGS was set too early");
 
             match migrate(paths).await {
@@ -113,6 +122,7 @@ impl Termination for CliResult {
 #[derive(Debug)]
 struct MigrationSettings {
     continue_migration: bool,
+    dry_run: bool,
 }
 
 static MIGRATION_SETTINGS: OnceCell<MigrationSettings> = OnceCell::const_new();

--- a/rust/migrate-wicked/src/migrate.rs
+++ b/rust/migrate-wicked/src/migrate.rs
@@ -50,6 +50,13 @@ impl Adapter for WickedAdapter {
 pub async fn migrate(paths: Vec<String>) -> Result<(), Box<dyn Error>> {
     let wicked = WickedAdapter::new(paths);
     let state = wicked.read()?;
+    let settings = MIGRATION_SETTINGS.get().unwrap();
+    if settings.dry_run {
+        for connection in state.connections {
+            log::debug!("{:#?}", connection);
+        }
+        return Ok(());
+    }
     let nm = NetworkManagerAdapter::from_system().await?;
     nm.write(&state)?;
     Ok(())


### PR DESCRIPTION
## Problem

`migrate-wicked show` is sort of a dry-run to assess if a migration would be successful, but it does differ a bit from `migrate` and also doesn't exit with an error exit code.

## Solution

Add a `--dry-run` argument to `migrate` that exits before writing the `NetworkState` to NetworkManager.

Fixes #38 

## Testing

- *Tested manually*