### PR TITLE
Add environment variables for clap args

### DIFF
--- a/rust/migrate-wicked/Cargo.toml
+++ b/rust/migrate-wicked/Cargo.toml
@@ -14,7 +14,7 @@ agama-lib = { path="../agama-lib" }
 regex = "1.9.5"
 agama-dbus-server = { path="../agama-dbus-server" }
 cidr = { version = "0.2.2", features = ["serde"] }
-clap = { version = "4.1.4", features = ["derive", "wrap_help"] }
+clap = { version = "4.1.4", features = ["derive", "wrap_help", "env"] }
 anyhow = "1.0.71"
 log = "0.4"
 simplelog = "0.12.1"

--- a/rust/migrate-wicked/src/main.rs
+++ b/rust/migrate-wicked/src/main.rs
@@ -43,15 +43,15 @@ pub enum Commands {
         paths: Vec<String>,
 
         /// Continue migration if warnings are encountered
-        #[arg(short, long, global = true)]
+        #[arg(short, long, global = true, env = "MIGRATE_WICKED_CONTINUE_MIGRATION")]
         continue_migration: bool,
 
         /// Run migration without sending connections to NetworkManager (can be run without NetworkManager installed)
-        #[arg(long, global = true)]
+        #[arg(long, global = true, env = "MIGRATE_WICKED_DRY_RUN")]
         dry_run: bool,
 
         /// Activate connections immediately
-        #[arg(long, global = true)]
+        #[arg(long, global = true, env = "MIGRATE_WICKED_ACTIVATE_CONNECTIONS")]
         activate_connections: bool,
     },
 }

--- a/rust/migrate-wicked/src/main.rs
+++ b/rust/migrate-wicked/src/main.rs
@@ -104,6 +104,11 @@ async fn run_command(cli: Cli) -> anyhow::Result<()> {
                 })
                 .expect("MIGRATION_SETTINGS was set too early");
 
+            log::debug!(
+                "Running migration with MigrationSettings: {:#?}",
+                MIGRATION_SETTINGS.get().unwrap()
+            );
+
             match migrate(paths).await {
                 Ok(()) => Ok(()),
                 Err(e) => Err(anyhow::anyhow!("Migration failed: {:?}", e)),


### PR DESCRIPTION
## Problem

For the migration container it would be nice to be able to control the args via environment variables

## Solution

Enable and add env to clap args

## Testing

- *Tested manually*: `MIGRATE_WICKED_DRY_RUN=true cargo run migrate -c tests/dummy/wicked_xml`