### PR TITLE
Fix integration tests for updated NM

### DIFF
--- a/rust/migrate-wicked/tests/bond_active-backup/system-connections/en0.nmconnection
+++ b/rust/migrate-wicked/tests/bond_active-backup/system-connections/en0.nmconnection
@@ -2,8 +2,10 @@
 id=en0
 uuid=38d979e6-aa0e-4bae-8cff-a6dda281d0c7
 type=ethernet
+controller=bond0
 interface-name=en0
 master=bond0
+port-type=bond
 slave-type=bond
 
 [ethernet]

--- a/rust/migrate-wicked/tests/bond_active-backup/system-connections/en1.nmconnection
+++ b/rust/migrate-wicked/tests/bond_active-backup/system-connections/en1.nmconnection
@@ -2,8 +2,10 @@
 id=en1
 uuid=9269bbb4-a771-406f-ba66-3f65ed15634c
 type=ethernet
+controller=bond0
 interface-name=en1
 master=bond0
+port-type=bond
 slave-type=bond
 
 [ethernet]

--- a/rust/migrate-wicked/tests/bridge1/system-connections/en0.nmconnection
+++ b/rust/migrate-wicked/tests/bridge1/system-connections/en0.nmconnection
@@ -2,8 +2,10 @@
 id=en0
 uuid=4c941c30-b610-470a-b24a-5a6c73ab6710
 type=ethernet
+controller=br0
 interface-name=en0
 master=br0
+port-type=bridge
 slave-type=bridge
 
 [ethernet]

--- a/rust/migrate-wicked/tests/bridge1/system-connections/en1.nmconnection
+++ b/rust/migrate-wicked/tests/bridge1/system-connections/en1.nmconnection
@@ -2,8 +2,10 @@
 id=en1
 uuid=f760dace-c275-4983-ab36-51c8e9642dfc
 type=ethernet
+controller=br0
 interface-name=en1
 master=br0
+port-type=bridge
 slave-type=bridge
 
 [ethernet]


### PR DESCRIPTION
## Problem

Integration tests are broken on the newest Tumbleweed snapshot because NM properties `master` and `slave-type` are now deprecated and just alias to `controller` and `port-type` respectively.

## Solution

Fix tests by adding new properties to relevant `.nmconnection` files