### PR TITLE
Show the git HEAD sha in version output

### DIFF
--- a/rust/migrate-wicked/build.rs
+++ b/rust/migrate-wicked/build.rs
@@ -1,0 +1,11 @@
+use std::process::Command;
+
+fn main() {
+    let output = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    let mut git_hash = String::from_utf8(output.stdout).unwrap();
+    git_hash.truncate(9);
+    println!("cargo:rustc-env=GIT_HEAD={}", git_hash);
+}

--- a/rust/migrate-wicked/build.rs
+++ b/rust/migrate-wicked/build.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 fn main() {
     let output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .unwrap();
     let mut git_hash = String::from_utf8(output.stdout).unwrap();

--- a/rust/migrate-wicked/src/main.rs
+++ b/rust/migrate-wicked/src/main.rs
@@ -17,7 +17,7 @@ use std::process::{ExitCode, Termination};
 use tokio::sync::OnceCell;
 
 #[derive(Parser)]
-#[command(name = "migrate-wicked", version, about, long_about = None)]
+#[command(name = "migrate-wicked", version(concat!(env!("CARGO_PKG_VERSION"),"~",env!("GIT_HEAD"))), about, long_about = None)]
 struct Cli {
     #[clap(flatten)]
     global_opts: GlobalOpts,


### PR DESCRIPTION
The argument `migrate-wicked --version` show something like
  migrate-wicked 0.1.0~7c9199b0f