### PR TITLE
Update tests to new behavior of NetworkManager

### DIFF
--- a/rust/migrate-wicked/tests/bond_active-backup/system-connections/en0.nmconnection
+++ b/rust/migrate-wicked/tests/bond_active-backup/system-connections/en0.nmconnection
@@ -4,9 +4,7 @@ uuid=38d979e6-aa0e-4bae-8cff-a6dda281d0c7
 type=ethernet
 controller=bond0
 interface-name=en0
-master=bond0
 port-type=bond
-slave-type=bond
 
 [ethernet]
 

--- a/rust/migrate-wicked/tests/bond_active-backup/system-connections/en1.nmconnection
+++ b/rust/migrate-wicked/tests/bond_active-backup/system-connections/en1.nmconnection
@@ -4,9 +4,7 @@ uuid=9269bbb4-a771-406f-ba66-3f65ed15634c
 type=ethernet
 controller=bond0
 interface-name=en1
-master=bond0
 port-type=bond
-slave-type=bond
 
 [ethernet]
 

--- a/rust/migrate-wicked/tests/bridge1/system-connections/en0.nmconnection
+++ b/rust/migrate-wicked/tests/bridge1/system-connections/en0.nmconnection
@@ -4,9 +4,7 @@ uuid=4c941c30-b610-470a-b24a-5a6c73ab6710
 type=ethernet
 controller=br0
 interface-name=en0
-master=br0
 port-type=bridge
-slave-type=bridge
 
 [ethernet]
 

--- a/rust/migrate-wicked/tests/bridge1/system-connections/en1.nmconnection
+++ b/rust/migrate-wicked/tests/bridge1/system-connections/en1.nmconnection
@@ -4,9 +4,7 @@ uuid=f760dace-c275-4983-ab36-51c8e9642dfc
 type=ethernet
 controller=br0
 interface-name=en1
-master=br0
 port-type=bridge
-slave-type=bridge
 
 [ethernet]
 


### PR DESCRIPTION
Since [MR#2009](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/2009) NetworkManager doesn't write offensive terms into keyfiles.

