### PR TITLE
Add commandline options to test.sh

### DIFF
--- a/rust/migrate-wicked/tests/test.sh
+++ b/rust/migrate-wicked/tests/test.sh
@@ -9,21 +9,82 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR
 TEST_DIRS=${TEST_DIRS:-$(ls -d */ | sed 's#/##')}
 NO_CLEANUP=${NO_CLEANUP:-0}
+LOG_LEVEL=1
 
 error_msg() {
-    echo -e "${RED}Error for test $1: $2${NC}"
+  log_error "Error for test $1:$2"
 }
 
-if [[ $(ls -A /etc/NetworkManager/system-connections/) ]]; then
-    echo -e "${RED}There are already NM connections. You may be running this script on a live system, which is highly discouraged!${NC}"
-    exit 1
-fi
+log_error() {
+  [ $LOG_LEVEL -gt 0 ] && echo -e "${RED}$@${NC}"
+}
+
+log_verbose() {
+    [ $LOG_LEVEL -gt 1 ] && echo -e "$@"
+}
 
 nm_cleanup() {
     for con in $(ls /etc/NetworkManager/system-connections/ | sed 's/\.nmconnection//'); do
         nmcli con delete $con
     done
 }
+
+print_help()
+{
+  echo "Usage:"
+  echo "   ./test [ARGUMENTS] [TEST_DIRS]"
+  echo ""
+  echo "Arguments:"
+  echo "  -v|--verbose            Be more verbose"
+  echo "  -q|--quiet              Be less verbose"
+  echo "  --nm-cleanup            Cleanup current NetworkManager config before start"
+  echo "  --no-cleanup            Do not cleanup NetworkManger after test"
+  echo "  -h|--help               Print this help"
+}
+
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  opt=$1; 
+  shift;
+  case $opt in
+    -v|--verbose)
+      LOG_LEVEL=$((LOG_LEVEL + 1))
+      ;;
+    --binary)
+      MIGRATE_WICKED_BIN=$1; shift
+      ;;
+    --nm-cleanup)
+      nm_cleanup
+      ;;
+    --no-cleanup)
+      NO_CLEANUP=1
+      ;;
+    -q|--quite)
+      [ $LOG_LEVEL -gt 0 ] && LOG_LEVEL=$((LOG_LEVEL - 1))
+      ;;
+    -h|--help)
+      print_help
+      exit 0;
+      ;;
+    -*|--*)
+      echo "Unknown option $opt"
+      exit 1
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$opt") # save positional arg
+      ;;
+  esac
+done
+
+if [ ${#POSITIONAL_ARGS[@]} -gt 0 ]; then
+  TEST_DIRS="${POSITIONAL_ARGS[@]}"
+fi
+
+if [[ $(ls -A /etc/NetworkManager/system-connections/) ]]; then
+    echo -e "${RED}There are already NM connections. You may be running this script on a live system, which is highly discouraged!${NC}"
+    exit 1
+fi
 
 if [ ! -f $MIGRATE_WICKED_BIN ]; then
     echo -e "${RED}No migrate-wicked binary found${NC}"
@@ -51,12 +112,14 @@ for test_dir in ${TEST_DIRS}; do
         show_args+=" --without-netconfig"
     fi
 
+    log_verbose "RUN: $MIGRATE_WICKED_BIN show $show_args $test_dir/wicked_xml"
     $MIGRATE_WICKED_BIN show $show_args $test_dir/wicked_xml
     if [ $? -ne 0 ] && [ "$expect_fail" = false ]; then
         error_msg ${test_dir} "show failed"
         FAILED_TESTS+=("${test_dir}::show")
     fi
 
+    log_verbose "RUN: $MIGRATE_WICKED_BIN migrate $migrate_args $test_dir/wicked_xml"
     $MIGRATE_WICKED_BIN migrate $migrate_args $test_dir/wicked_xml
     if [ $? -ne 0 ] && [ "$expect_fail" = false ]; then
         error_msg ${test_dir} "migration failed"
@@ -67,12 +130,17 @@ for test_dir in ${TEST_DIRS}; do
     fi
 
     for cmp_file in $(ls -1 $test_dir/system-connections/); do
-        diff --unified=0 --color=always -I uuid -I timestamp $test_dir/system-connections/$cmp_file /etc/NetworkManager/system-connections/${cmp_file}
-        if [ $? -ne 0 ]; then
+        a="$test_dir/system-connections/$cmp_file"
+        b="/etc/NetworkManager/system-connections/${cmp_file}"
+        diff_cmd="diff --unified=0 --color=always -I uuid -I timestamp $a $b" 
+        log_verbose "RUN: $diff_cmd"
+        if $diff_cmd; then
+            echo -e "${GREEN}Migration for connection ${cmp_file/\.nmconnection/} successful${NC}"
+        else
+            diff_cmd="diff  -I uuid -I timestamp -y --color=always $a $b"
+            log_verbose "RUN: $diff_cmd\n$($diff_cmd)\n" 
             error_msg ${test_dir} "$cmp_file didn't match"
             FAILED_TESTS+=("${test_dir}::compare_config::${cmp_file}")
-        else
-            echo -e "${GREEN}Migration for connection ${cmp_file/\.nmconnection/} successful${NC}"
         fi
     done
 


### PR DESCRIPTION
I know the intention of that runner was the `ci`, but I use it also in development so these command line options comes handy:
```
Usage:
   ./test [ARGUMENTS] [TEST_DIRS]

Arguments:
  -v|--verbose            Be more verbose
  -q|--quiet              Be less verbose
  --nm-cleanup            Cleanup current NetworkManager config before start
  --no-cleanup            Do not cleanup NetworkManger after test
  -h|--help               Print this help
```

e.g. starting only the wireless tests it's easy to run it like:
```
./test.sh wireless
```