### PR TITLE
Improve log output

### DIFF
--- a/rust/migrate-wicked/Cargo.lock
+++ b/rust/migrate-wicked/Cargo.lock
@@ -1905,6 +1905,7 @@ dependencies = [
  "serde",
  "serde_ignored",
  "serde_json",
+ "serde_path_to_error",
  "serde_with",
  "serde_yaml",
  "simplelog",

--- a/rust/migrate-wicked/Cargo.toml
+++ b/rust/migrate-wicked/Cargo.toml
@@ -26,6 +26,7 @@ serde_ignored = "0.1.9"
 uuid = { version = "1.3.4", features = ["v4"] }
 macaddr = "1.0"
 dotenv = "0.15.0"
+serde_path_to_error = "0.1.16"
 
 [[bin]]
 name = "migrate-wicked"

--- a/rust/migrate-wicked/src/main.rs
+++ b/rust/migrate-wicked/src/main.rs
@@ -34,7 +34,7 @@ struct Cli {
 
 #[derive(Debug, Args)]
 struct GlobalOpts {
-    #[arg(long, global = true, default_value_t = LevelFilter::Warn, value_parser = clap::builder::PossibleValuesParser::new(["TRACE", "DEBUG", "INFO", "WARN", "ERROR"]).map(|s| s.parse::<LevelFilter>().unwrap()),)]
+    #[arg(long, global = true, default_value_t = LevelFilter::Info, value_parser = clap::builder::PossibleValuesParser::new(["TRACE", "DEBUG", "INFO", "WARN", "ERROR"]).map(|s| s.parse::<LevelFilter>().unwrap()),)]
     pub log_level: LevelFilter,
 
     #[arg(long, global = true, env = "MIGRATE_WICKED_WITHOUT_NETCONFIG")]

--- a/rust/migrate-wicked/src/main.rs
+++ b/rust/migrate-wicked/src/main.rs
@@ -15,6 +15,7 @@ use log::*;
 use migrate::migrate;
 use reader::read as wicked_read;
 use serde::Serialize;
+use simplelog::ConfigBuilder;
 use std::process::{ExitCode, Termination};
 use tokio::sync::OnceCell;
 
@@ -188,9 +189,14 @@ static MIGRATION_SETTINGS: OnceCell<MigrationSettings> = OnceCell::const_new();
 async fn main() -> CliResult {
     let cli = Cli::parse();
 
+    let config = ConfigBuilder::new()
+        .set_time_level(LevelFilter::Off)
+        .add_filter_allow("migrate_wicked".to_string())
+        .build();
+
     simplelog::TermLogger::init(
         cli.global_opts.log_level,
-        simplelog::Config::default(),
+        config,
         simplelog::TerminalMode::Stderr,
         simplelog::ColorChoice::Auto,
     )

--- a/rust/migrate-wicked/src/main.rs
+++ b/rust/migrate-wicked/src/main.rs
@@ -141,7 +141,7 @@ async fn run_command(cli: Cli) -> anyhow::Result<()> {
 
             match migrate(paths).await {
                 Ok(()) => Ok(()),
-                Err(e) => Err(anyhow::anyhow!("Migration failed: {:?}", e)),
+                Err(e) => Err(anyhow::anyhow!("Migration failed: {}", e)),
             }
         }
     }
@@ -197,7 +197,7 @@ async fn main() -> CliResult {
     .unwrap();
 
     if let Err(error) = run_command(cli).await {
-        eprintln!("{:?}", error);
+        log::error!("{}", error);
         return CliResult::Error;
     }
 


### PR DESCRIPTION
## Problem

Currently the output has a few issues like:
* The actual error being printed in just plain text which takes the attention away from it
* If an error within the xml appeared it doesn't show where the error is at
* Infos don't get shown because setting the log level to `Info` also shows a lot irrelevant agama infos
* Useless timestamps

## Solution

Fix all of the above.
A new output would e.g. be:
```
[WARN] Unhandled field in interface wlan_eap0: control
[WARN] Unhandled field in interface wlan_eap1: control
[WARN] Unhandled field in interface wlan_eap1: ipv4.arp-verify
[WARN] Unhandled field in interface wlan_eap1: ipv6.privacy
[WARN] Unhandled field in interface wlan_eap1: ipv6.accept-redirects
[WARN] Unhandled field in interface wlan_eap2: control
[WARN] Unhandled field in interface wlan_eap2: ipv4.arp-verify
[WARN] Unhandled field in interface wlan_eap2: ipv6.privacy
[WARN] Unhandled field in interface wlan_eap2: ipv6.accept-redirects
[INFO] Certificate type 'file' may not work as intended
[INFO] EAP pairwise chipher not supported, leaving empty
```
```
[ERROR] Error at [0].wireless.networks.network[0].wpa-eap.pairwise-cipher: Matching variant not found
[ERROR] Migration failed: Matching variant not found
```
```
[WARN] Unhandled field in interface wlan_eap0: control
[WARN] Unhandled field in interface wlan_eap1: control
[WARN] Unhandled field in interface wlan_eap1: ipv4.arp-verify
[WARN] Unhandled field in interface wlan_eap1: ipv6.privacy
[WARN] Unhandled field in interface wlan_eap1: ipv6.accept-redirects
[WARN] Unhandled field in interface wlan_eap2: control
[WARN] Unhandled field in interface wlan_eap2: ipv4.arp-verify
[WARN] Unhandled field in interface wlan_eap2: ipv6.privacy
[WARN] Unhandled field in interface wlan_eap2: ipv6.accept-redirects
[ERROR] Migration failed: Unhandled fields
```


## Testing

- *Tested manually*