### PR TITLE
Skip files not ending in .xml in directories

### DIFF
--- a/rust/migrate-wicked/src/reader.rs
+++ b/rust/migrate-wicked/src/reader.rs
@@ -101,6 +101,14 @@ pub fn read(paths: Vec<String>) -> Result<InterfacesResult, anyhow::Error> {
         if path.is_dir() {
             let files = recurse_files(path)?;
             for file in files {
+                match file.extension() {
+                    None => continue,
+                    Some(ext) => {
+                        if !ext.eq("xml") {
+                            continue;
+                        }
+                    }
+                }
                 let mut read_xml = read_xml_file(file)?;
                 if result.warning.is_none() && read_xml.warning.is_some() {
                     result.warning = read_xml.warning


### PR DESCRIPTION
## Problem

Migration doesn't match wicked in using the xml files in a directory.

## Solution

Only use files that end with `.xml` when a directory is specified. Single files still can still be without `.xml`

## Testing

- *Tested manually*